### PR TITLE
Add FreeEQ8

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@
 - **[SWH Plugins](http://plugin.org.uk/ladspa-swh/)** - Large collection of LADSPA audio processing plugins.
 - **[TAP Plugins](http://tap-plugins.sourceforge.net/)** - Collection of audio processing plugins including delays and reverbs.
 - **[Valhalla Supermassive](https://valhalladsp.com/shop/reverb/valhalla-supermassive/)** - A popular plugin for creating massive reverbs and delays.
+- **[FreeEQ8](https://github.com/GareBear99/FreeEQ8)** - Open-source 8-band parametric EQ with linear phase, dynamic EQ and match EQ.
 
 ## 🌲 Field Recording & Capture
 


### PR DESCRIPTION
Adds FreeEQ8, a free and open-source JUCE-based 8-band parametric EQ plugin.

FreeEQ8 fits the Effects & Processing section as a sound design and music production EQ effect with public source code and VST3/AU/Standalone support.

Repository: https://github.com/GareBear99/FreeEQ8