### PR TITLE
Fix weekly link-check: grant issues:write, reduce false-positive noise

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -6,6 +6,10 @@ on:
     - cron: "0 6 * * 1"
   workflow_dispatch: {}
 
+permissions:
+  contents: read
+  issues: write
+
 jobs:
   link-check:
     runs-on: ubuntu-latest

--- a/.markdown-link-check.json
+++ b/.markdown-link-check.json
@@ -5,5 +5,6 @@
   "retryOn429": true,
   "retryCount": 3,
   "fallbackRetryDelay": "30s",
-  "aliveStatusCodes": [200, 206, 301, 302, 303, 307, 308, 403, 429]
+  "timeout": "20s",
+  "aliveStatusCodes": [200, 206, 301, 302, 303, 307, 308, 403, 418, 429]
 }


### PR DESCRIPTION
## Summary
- Root cause of the failing run (https://github.com/landscape82/awesome-sound-design-resources/actions/runs/32026684531): the repo's default GITHUB_TOKEN permission is `read`, and link-check.yml never requested `issues: write` explicitly, so the "Open issue on failure" step errored with `HttpError: Resource not accessible by integration` instead of filing the tracking issue. Added an explicit `permissions:` block (matching what changelog.yml already does for `contents: write`).
- Added `418` to `aliveStatusCodes` (Cloudflare's bot-block status, hit by freedesktop.org/wiki/Software/PulseAudio) and bumped the request timeout to 20 seconds, to cut down on false positives from sites that just block or slow-walk bots.

## Not addressed here
The same run found roughly 30 links that look genuinely dead (real 404s, a DNS failure on republic.heute, etc). That is content rot in the list itself and needs per-entry verification/replacement, not a CI config change — worth a separate follow-up pass rather than bundling into this fix.

## Test plan
- [x] Reviewed the repo's Actions default token permissions (read) via the GitHub API to confirm root cause
- [ ] workflow_dispatch run of Weekly Link Check on this branch/after merge succeeds in filing (or updating) the broken-link issue instead of erroring
