### PR TITLE
Bump GitHub Actions to Node 24 majors (fix deprecation warning)

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -13,7 +13,7 @@ jobs:
   changelog:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -14,7 +14,7 @@ jobs:
   link-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Check links
         id: link-check

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,9 +10,9 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: "20"
           cache: "npm"


### PR DESCRIPTION
## Summary
CI runs (e.g. https://github.com/landscape82/awesome-sound-design-resources/actions/runs/32029236437) print a deprecation warning: `actions/checkout@v4` targets Node.js 20, which GitHub-hosted runners are now forcing onto Node.js 24 and will stop supporting entirely. Bumped the actions that had a documented Node 24 migration to the first major version that made that switch:

- `actions/checkout@v4` -> `v5` (confirmed via the v5.0.0 release notes: "Update actions checkout to use node 24")
- `actions/setup-node@v4` -> `v5` (v5.0.0 release notes: "Upgrade action to use node24")
- `actions/setup-python@v5` -> `v6` (v6.0.0 release notes: "Upgrade to node 24")

No workflow behavior changes — same steps, same inputs, just newer runtimes under the hood.

## Not bumped
`gaurav-nelson/github-action-markdown-link-check@v1` and `JasonEtco/create-an-issue@v2` are third-party actions; the latter has no newer major available (latest is v2.9.2) so there's nothing to bump there. Not in scope for this PR.