### PR TITLE
Fix bot commits blocked by branch protection

### DIFF
--- a/.github/workflows/badges.yml
+++ b/.github/workflows/badges.yml
@@ -9,6 +9,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   badges:
@@ -25,8 +26,26 @@ jobs:
           {"schemaVersion":1,"label":"list entries","message":"${count}","color":"blue"}
           EOF
 
-      - name: Commit badge
-        uses: stefanzweifel/git-auto-commit-action@v7
-        with:
-          commit_message: "chore: update entries badge"
-          file_pattern: .github/badges/entries.json
+      # main is protected (requires a PR + passing "lint" check), so this
+      # can't push directly - it opens a small bot PR and auto-merges it
+      # instead, once the change actually differs from what's on main.
+      - name: Open PR for entries badge update
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          if git diff --quiet -- .github/badges/entries.json; then
+            echo "No badge change, skipping."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          BRANCH="bot/entries-badge-${{ github.run_id }}"
+          git checkout -b "$BRANCH"
+          git add .github/badges/entries.json
+          git commit -m "chore: update entries badge"
+          git push origin "$BRANCH"
+          gh pr create --base main --head "$BRANCH" \
+            --title "chore: update entries badge" \
+            --body "Automated update from the \`badges\` workflow."
+          gh pr merge "$BRANCH" --auto --squash --delete-branch

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   changelog:
@@ -42,8 +43,26 @@ jobs:
           ' CHANGELOG.md > CHANGELOG.md.tmp
           mv CHANGELOG.md.tmp CHANGELOG.md
 
-      - name: Commit changelog
-        uses: stefanzweifel/git-auto-commit-action@v7
-        with:
-          commit_message: "docs: update changelog"
-          file_pattern: CHANGELOG.md
+      # main is protected (requires a PR + passing "lint" check), so this
+      # can't push directly - it opens a small bot PR and auto-merges it
+      # instead, once the change actually differs from what's on main.
+      - name: Open PR for changelog update
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          if git diff --quiet -- CHANGELOG.md; then
+            echo "No changelog change, skipping."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          BRANCH="bot/changelog-${{ github.run_id }}"
+          git checkout -b "$BRANCH"
+          git add CHANGELOG.md
+          git commit -m "docs: update changelog"
+          git push origin "$BRANCH"
+          gh pr create --base main --head "$BRANCH" \
+            --title "docs: update changelog" \
+            --body "Automated update from the \`changelog\` workflow."
+          gh pr merge "$BRANCH" --auto --squash --delete-branch

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -9,6 +9,7 @@ on:
 permissions:
   contents: write
   issues: write
+  pull-requests: write
 
 jobs:
   link-check:
@@ -85,12 +86,30 @@ jobs:
           {"schemaVersion":1,"label":"broken links","message":"${broken}","color":"${color}"}
           EOF
 
-      - name: Commit broken-links badge
+      # main is protected (requires a PR + passing "lint" check), so this
+      # can't push directly - it opens a small bot PR and auto-merges it
+      # instead, once the change actually differs from what's on main.
+      - name: Open PR for broken-links badge update
         if: always()
-        uses: stefanzweifel/git-auto-commit-action@v7
-        with:
-          commit_message: "chore: update broken-links badge"
-          file_pattern: .github/badges/broken-links.json
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          if git diff --quiet -- .github/badges/broken-links.json; then
+            echo "No badge change, skipping."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          BRANCH="bot/broken-links-badge-${{ github.run_id }}"
+          git checkout -b "$BRANCH"
+          git add .github/badges/broken-links.json
+          git commit -m "chore: update broken-links badge"
+          git push origin "$BRANCH"
+          gh pr create --base main --head "$BRANCH" \
+            --title "chore: update broken-links badge" \
+            --body "Automated update from the \`link-check\` workflow."
+          gh pr merge "$BRANCH" --auto --squash --delete-branch
 
       # Replaces JasonEtco/create-an-issue@v2: that action has no Node 24 build
       # (latest release v2.9.2), so it kept tripping the runner's Node 20


### PR DESCRIPTION
- `link-check.yml`, `badges.yml`, `changelog.yml` all pushed straight to `main` via `git-auto-commit-action`.
- Since main now requires a PR + passing `lint` check, those pushes were silently rejected (`GH006: Protected branch update failed`).
- This is why the `Broken Links` badge stayed stuck at `0` despite issue #6 reporting 60 broken links.
- Fix: each workflow now opens a small bot PR and sets it to auto-merge instead of pushing directly.
- Also enabled `allow_auto_merge` on the repo (required for `gh pr merge --auto`).